### PR TITLE
Bump ansible-collection-azimuth-ops for Zenith update

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@
 collections:
   - name: https://github.com/stackhpc/ansible-collection-azimuth-ops.git
     type: git
-    version: 97ea6476f3a16e073db1a2129c09980b2a0302ff
+    version: a40a2ded16c8fe5fdafde642b23922f2adee6684


### PR DESCRIPTION
Azimuth-ops update bumps Zenith chart version to
0.1.0-dev.0.main.219, which adds additional logging and simplifies the retry/reconciliation process during service sync.

https://github.com/stackhpc/ansible-collection-azimuth-ops/pull/81