### PR TITLE
Port-forward to grafana not monitoring

### DIFF
--- a/bin/port-forward
+++ b/bin/port-forward
@@ -57,7 +57,7 @@ case "$1" in
     service="consul-ui"
     remote_port="80"
     ;;
-  monitoring)
+  grafana)
     name="Grafana"
     namespace="monitoring-system"
     service="kube-prometheus-stack-grafana"

--- a/docs/debugging/access-monitoring.md
+++ b/docs/debugging/access-monitoring.md
@@ -15,7 +15,7 @@ To view monitoring dashboards in Grafana, use the following command to expose th
 interface on a local port:
 
 ```sh
-./bin/port-forward monitoring 3000
+./bin/port-forward grafana 3000
 ```
 
 This will make the Grafana interface available at <http://localhost:3000>. Log in with the default


### PR DESCRIPTION
All other services are accessed by their service name, this brings grafana in-line with the rest of the pre-configured port-forward target names.