### PR TITLE
Only run CI on stackhpc/azimuth-config

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   # This job exists so that PRs from outside the main repo are rejected
   fail_on_remote:
+    if: github.repository == 'stackhpc/azimuth-config'
     runs-on: ubuntu-latest
     steps:
       - name: PR must be from a branch in the azimuth-config repo


### PR DESCRIPTION
Forks run the CI and send "failed" notifications.

Just gating this job is sufficient, as other parts of the CI are dependent on it succeeding.