### PR TITLE
Fix seed-ssh for OpenTofu

### DIFF
--- a/bin/seed-ssh
+++ b/bin/seed-ssh
@@ -28,6 +28,18 @@ ansible_variable() {
 terraform_binary_directory="$(ansible_variable terraform_binary_directory)"
 export PATH="$terraform_binary_directory:$PATH"
 
+# If tofu is available in the path, use that
+if which tofu >/dev/null; then
+  terraform_binary_path="$(which tofu)"
+elif which terraform >/dev/null; then
+  echo "OpenTofu is not installed - falling back to Terraform" >&2
+  echo "This may cause issues, especially when downloading providers" >&2
+  terraform_binary_path="$(which terraform)"
+else
+  echo "Unable to find OpenTofu or Terraform" >&2
+  exit 1
+fi
+
 # Make a working directory for seed-ssh related stuff
 work_dir="$(ansible_variable work_directory)/seed-ssh"
 mkdir -p "$work_dir"
@@ -48,7 +60,7 @@ terraform {
 }
 EOF
     ansible_variable terraform_backend_config > "$terraform_dir/backend_config.json"
-    terraform \
+    $terraform_binary_path \
       -chdir="$terraform_dir" \
       init \
       -input=false \
@@ -58,7 +70,7 @@ fi
 
 # Read the required variables from the Terraform state
 tfstate_file="$work_dir/tfstate"
-terraform -chdir="$terraform_dir" state pull > "$tfstate_file"
+$terraform_binary_path -chdir="$terraform_dir" state pull > "$tfstate_file"
 node_ip="$(jq -r '.outputs.cluster_gateway_ip.value // ""' "$tfstate_file")"
 deploy_key="$work_dir/deploy-key"
 jq -r '.outputs.cluster_ssh_private_key.value // ""' "$tfstate_file" > "$deploy_key"


### PR DESCRIPTION
When using `seed-ssh` in a production context, where there isn't a locally downloaded OpenTofu install from running `stackhpc.azimuth_ops.provision` but Terraform is present, installing providers can fail because the certs for the OpenTofu registry are not trusted by Terraform.

This PR fixes `seed-ssh` to use OpenTofu by default if present, and emits a warning when falling back to Terraform.