### PR TITLE
Add required packages for CI execution

### DIFF
--- a/bin/ci-setup
+++ b/bin/ci-setup
@@ -40,7 +40,7 @@ if [ -z "$AZIMUTH_ENVIRONMENT" ]; then
 fi
 
 run_apt update
-run_apt install -y git python3 python3-pip qemu-utils
+run_apt install -y git python3 python3-pip qemu-utils zip
 
 pip install -U pip
 pip install -r requirements.txt

--- a/bin/ci-setup
+++ b/bin/ci-setup
@@ -40,7 +40,16 @@ if [ -z "$AZIMUTH_ENVIRONMENT" ]; then
 fi
 
 run_apt update
-run_apt install -y git jq python3 python3-pip qemu-utils zip
+run_apt install -y git jq python3 python3-pip qemu-utils software-properties-common zip
+
+if [ "$(id -u)" -eq 0 ]; then
+  add-apt-repository ppa:mozillateam/ppa
+else
+  sudo add-apt-repository ppa:mozillateam/ppa
+fi
+
+run_apt update
+run_apt install -y -t 'o=LP-PPA-mozillateam' firefox
 
 pip install -U pip
 pip install -r requirements.txt

--- a/bin/ci-setup
+++ b/bin/ci-setup
@@ -40,7 +40,7 @@ if [ -z "$AZIMUTH_ENVIRONMENT" ]; then
 fi
 
 run_apt update
-run_apt install -y git python3 python3-pip qemu-utils zip
+run_apt install -y git jq python3 python3-pip qemu-utils zip
 
 pip install -U pip
 pip install -r requirements.txt


### PR DESCRIPTION
Testing at Graphcore indicates the zip package is needed, otherwise the following error results:

```
TASK [stackhpc.terraform.install : Download Terraform binary] ******************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to find handler for \"/root/.ansible/tmp/ansible-tmp-1711384768.5950997-5388-98444872472118/tofu_1.6.1_linux_amd641a4f1kmx.zip\". Make sure the required command to extract the file is installed.
```