### PR TITLE
Clarify secret requirements

### DIFF
--- a/docs/configuration/08-zenith.md
+++ b/docs/configuration/08-zenith.md
@@ -17,7 +17,7 @@ zenith_registrar_subdomain_token_signing_key: "<some secret key>"
 
 !!! tip
 
-    This key should be a long, random string - at least 32 bytes (256 bits) is recommended.
+    This key must be a long, random string - at least 32 bytes (256 bits) is required.
     A suitable key can be generated using `openssl rand -hex 32`.
 
 !!! danger

--- a/environments/example/inventory/group_vars/all/secrets.yml
+++ b/environments/example/inventory/group_vars/all/secrets.yml
@@ -4,6 +4,9 @@
 # It should be encrypted if stored in version control
 # https://stackhpc.github.io/azimuth-config/repository/secrets/
 #####
+# Unless explicitly mentioned otherwise, a long, random string - at least 32 bytes (256 bits) is recommended.
+# A suitable key can be generated using the following command.
+# openssl rand -hex 32
 
 # https://stackhpc.github.io/azimuth-config/configuration/05-secret-key/
 # The secret key for signing Azimuth cookies
@@ -15,12 +18,14 @@ keycloak_admin_password: "<secure password>"
 
 # https://stackhpc.github.io/azimuth-config/configuration/08-zenith/
 # The secret key for signing Zenith registrar tokens
+# This MUST be a minimum of 32 characters
 zenith_registrar_subdomain_token_signing_key: "<secure secret key>"
 
 # https://stackhpc.github.io/azimuth-config/configuration/10-kubernetes-clusters/#harbor-registry
 # The password for the Harbor admin account
 harbor_admin_password: "<secure password>"
 # The secret key for Harbor
+# This MUST be exactly 16 alphanumeric characters
 harbor_secret_key: "<secure secret key>"
 
 # https://stackhpc.github.io/azimuth-config/configuration/14-monitoring/#accessing-web-interfaces


### PR DESCRIPTION
For some secrets there are specific requirements that extend beyond recommended/best practices.
Let's have details in the secrets.yml

Some of these requirements are already captured in the docs - e.g. harbor_secret-key
https://stackhpc.github.io/azimuth-config/configuration/10-kubernetes-clusters/#harbor-registry

Others have requirements that are also not validated or documented but cause quiet breakage - e.g. 
zenith_registrar_subdomain_token_signing_key has a minimum req of 32 bytes


Zenith requirement captured from zenith-server-registrar pod logs

```
 File "/venv/lib/python3.10/site-packages/pydantic/main.py", line 176, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for RegistrarConfig
subdomainTokenSigningKey
  Data should have at least 32 bytes [type=bytes_too_short, input_value='XXXXXXXXXX', input_type=str]
    For further information visit https://errors.pydantic.dev/2.7/v/bytes_too_short
```
