### PR TITLE
Add performance tuning and reporting in Ansible config

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -11,5 +11,3 @@ runs:
         source ./ci.env
         source ./bin/activate "$AZIMUTH_CONFIG_ENVIRONMENT" "$AZIMUTH_ENVIRONMENT"
         ansible-playbook stackhpc.azimuth_ops.provision -e @extra-vars.yml
-      env:
-        ANSIBLE_CALLBACKS_ENABLED: ansible.posix.profile_tasks

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -153,8 +153,9 @@ runs:
         ansible_var() {
             ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
             ANSIBLE_STDOUT_CALLBACK=json \
+            ANSIBLE_JSON_INDENT=0 \
             ansible -m debug -a "var=$1" -e @extra-vars.yml all | \
-              jq -r ".plays[0].tasks[0].hosts.localhost.$1"
+               jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
         }
 
         EXTNET_ID="$(ansible_var infra_external_network_id)"

--- a/.github/environments/arcus-ha/ansible.cfg
+++ b/.github/environments/arcus-ha/ansible.cfg
@@ -2,8 +2,14 @@
 inventory = ../../../environments/base/inventory,../../../environments/ha/inventory,../../../environments/demo/inventory,../common/inventory,../arcus/inventory,./inventory
 roles_path = ../../../.ansible/roles
 collections_path = ../../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
+# Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
 
 [ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
 retries = 3

--- a/.github/environments/arcus/ansible.cfg
+++ b/.github/environments/arcus/ansible.cfg
@@ -2,8 +2,14 @@
 inventory = ../../../environments/base/inventory,../../../environments/singlenode/inventory,../../../environments/demo/inventory,../common/inventory,./inventory
 roles_path = ../../../.ansible/roles
 collections_path = ../../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
+# Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
 
 [ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
 retries = 3

--- a/.github/environments/leafcloud-ha/ansible.cfg
+++ b/.github/environments/leafcloud-ha/ansible.cfg
@@ -2,8 +2,14 @@
 inventory = ../../../environments/base/inventory,../../../environments/ha/inventory,../../../environments/demo/inventory,../common/inventory,../leafcloud/inventory,./inventory
 roles_path = ../../../.ansible/roles
 collections_path = ../../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
+# Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
 
 [ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
 retries = 3

--- a/.github/environments/leafcloud/ansible.cfg
+++ b/.github/environments/leafcloud/ansible.cfg
@@ -2,8 +2,14 @@
 inventory = ../../../environments/base/inventory,../../../environments/singlenode/inventory,../../../environments/demo/inventory,../common/inventory,./inventory
 roles_path = ../../../.ansible/roles
 collections_path = ../../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
+# Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
 
 [ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
 retries = 3

--- a/bin/create-debug-bundle
+++ b/bin/create-debug-bundle
@@ -16,8 +16,9 @@ fi
 ansible_variable() {
     ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
     ANSIBLE_STDOUT_CALLBACK=json \
+    ANSIBLE_JSON_INDENT=0 \
     ansible -m debug -a "var=$1" all | \
-      jq -r ".plays[0].tasks[0].hosts.localhost.$1"
+       jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
 }
 
 

--- a/bin/port-forward
+++ b/bin/port-forward
@@ -17,8 +17,9 @@ fi
 ansible_variable() {
     ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
     ANSIBLE_STDOUT_CALLBACK=json \
+    ANSIBLE_JSON_INDENT=0 \
     ansible -m debug -a "var=$1" all | \
-      jq -r ".plays[0].tasks[0].hosts.localhost.$1"
+       jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
 }
 
 

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -16,8 +16,9 @@ fi
 ansible_variable() {
     ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
     ANSIBLE_STDOUT_CALLBACK=json \
+    ANSIBLE_JSON_INDENT=0 \
     ansible -m debug -a "var=$1" all | \
-      jq -r ".plays[0].tasks[0].hosts.localhost.$1"
+       jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
 }
 
 

--- a/bin/seed-ssh
+++ b/bin/seed-ssh
@@ -17,8 +17,9 @@ fi
 ansible_variable() {
     ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
     ANSIBLE_STDOUT_CALLBACK=json \
+    ANSIBLE_JSON_INDENT=0 \
     ansible -m debug -a "var=$1" all | \
-      jq -r ".plays[0].tasks[0].hosts.localhost.$1"
+       jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
 }
 
 

--- a/bin/tilt-up
+++ b/bin/tilt-up
@@ -24,8 +24,9 @@ fi
 ansible_variable() {
     ANSIBLE_LOAD_CALLBACK_PLUGINS=true \
     ANSIBLE_STDOUT_CALLBACK=json \
+    ANSIBLE_JSON_INDENT=0 \
     ansible -m debug -a "var=$1" all | \
-      jq -r ".plays[0].tasks[0].hosts.localhost.$1"
+       jq -r -R "fromjson? | .plays[0].tasks[0].hosts.localhost.$1"
 }
 
 

--- a/environments/capi-mgmt-example/ansible.cfg
+++ b/environments/capi-mgmt-example/ansible.cfg
@@ -4,6 +4,14 @@
 inventory = ../base/inventory,../ha/inventory,../capi-mgmt/inventory,./inventory
 roles_path = ../../.ansible/roles
 collections_path = ../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
 # Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
+
+[ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
+retries = 3

--- a/environments/demo/ansible.cfg
+++ b/environments/demo/ansible.cfg
@@ -2,5 +2,14 @@
 inventory = ../base/inventory,../singlenode/inventory,./inventory
 roles_path = ../../.ansible/roles
 collections_path = ../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
+# Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
+
+[ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
+retries = 3

--- a/environments/example/ansible.cfg
+++ b/environments/example/ansible.cfg
@@ -4,6 +4,14 @@
 inventory = ../base/inventory,../ha/inventory,./inventory
 roles_path = ../../.ansible/roles
 collections_path = ../../.ansible/collections
+stdout_callback = yaml
+bin_ansible_callbacks = True
+callbacks_enabled = ansible.posix.profile_tasks
 
 # Disable host key checking as hosts are dynamically replaced
 host_key_checking = False
+
+[ssh_connection]
+pipelining = True
+ssh_extra_args = -o ControlPersist=1h
+retries = 3


### PR DESCRIPTION
- Enable SSH pipelining: This results in almost a 50% reduction in runtime on a no-op deployment
- Add task profiling: Allows simple viewing of how long tasks are taking
- Add stdout callback formatting: Format task stdouts as YAML

Add these configurations to example and CI environments.